### PR TITLE
初回起動に OpenAI Module が必要だったので足す

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ CraftForgeは、開発者と非開発者双方に対し、カスタマイズ可�
   ```sh
   pip install flet
   pip install cryptography
+  pip install openai
   ```
 
 ### Installation


### PR DESCRIPTION
### 直面したエラー
```
$ flet run app.py
Traceback (most recent call last):
  File "/Users/yakkun/ghq/github.com/hamatz/chatgpt_minimal_starter_kit/app.py", line 5, in <module>
    from plugin_manager import PluginManager
  File "/Users/yakkun/ghq/github.com/hamatz/chatgpt_minimal_starter_kit/plugin_manager.py", line 16, in <module>
    from api import API
  File "/Users/yakkun/ghq/github.com/hamatz/chatgpt_minimal_starter_kit/api.py", line 2, in <module>
    from openai import AzureOpenAI, OpenAI
ModuleNotFoundError: No module named 'openai'
```

### うーん？
多分この辺はそのうち `pipenv` らへんでどうにかするだろう、けど現状は必要そうなので README に足しておきました